### PR TITLE
feat: added optional `pre-commit` config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: end-of-file-fixer
+
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.5
+    hooks:
+      - id: remove-crlf
+
+  - repo: https://github.com/Calinou/pre-commit-luacheck
+    rev: v1.0.0
+    hooks:
+      - id: luacheck
+        verbose: true
+
+  - repo: local
+    hooks:
+      - id: stylua
+        name: StyLua
+        language: system
+        entry: stylua
+        types: [lua]
+        verbose: true


### PR DESCRIPTION
## Reasoning

[`pre-commit`](https://pre-commit.com) is a useful tool for running hooks on commit.
It is optional to use, but really useful!

The config here includes a StyLua hook, a Luacheck hook, and EOL checks.