### PR TITLE
fix: snippet items trigger errors on accept

### DIFF
--- a/lua/blink-cmp-env.lua
+++ b/lua/blink-cmp-env.lua
@@ -141,7 +141,7 @@ function M:setup_completion_items()
 
 		table.insert(self.completion_items, {
 			label = key,
-			insertTextFormat = vim.lsp.protocol.InsertTextFormat.Snippet,
+			insertTextFormat = vim.lsp.protocol.InsertTextFormat.PlainText,
 			insertText = value,
 			kind = require("blink.cmp.types").CompletionItemKind.Snippet,
 			documentation = documentation,


### PR DESCRIPTION
For snippet items, the value of the environment variable is used as the item's `insertText`.

Errors are triggered if the snippet item's `insertText` contains lsp snippets special constructs like `$`. This is due to blink.cmp trying to parse them as lsp snippets.

With this commit, snippet item's `insertTextFormat` is set to `PlainText`. Thus telling blink.cmp to treat the `insertText` as is and not parsing it as lsp snippets syntax.

Closes: #8