### PR TITLE
fix: module `blink.cmp.lib.async` is not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Inspired by [cmp-env](https://github.com/bydlw98/cmp-env).
 {
     "saghen/blink.cmp",
     dependencies = {
+        "saghen/blink.lib", -- required only for blink.cmp v2 users
         "bydlw98/blink-cmp-env",
     },
     opts = {

--- a/lua/blink-cmp-env.lua
+++ b/lua/blink-cmp-env.lua
@@ -1,6 +1,13 @@
 --- @module 'blink.cmp'
 
-local async = require("blink.cmp.lib.async")
+-- TODO: remove "blink.cmp.lib.async" module when blink.cmp v2 is stable.
+local task_ok, task = pcall(function()
+	return require("blink.cmp.lib.async").task
+end)
+
+if not task_ok then
+	task = require("blink.lib.task")
+end
 
 --- @class blink-cmp-env.Options
 --- @field item_kind? uinteger
@@ -89,7 +96,7 @@ end
 --- @param callback fun(...: any)
 --- @return fun()
 function M:get_completions(ctx, callback)
-	local task = async.task.empty():map(function()
+	local chained_task = task.new(function()
 		local trigger_chars = self:get_trigger_characters()
 		local start_col = ctx.bounds.start_col
 
@@ -115,7 +122,7 @@ function M:get_completions(ctx, callback)
 	end)
 
 	return function()
-		task:cancel()
+		chained_task:cancel()
 	end
 end
 


### PR DESCRIPTION
In blink.cmp v2, the async module has been moved into a separate blink.lib plugin.

To resolve this, we use the `blink.cmp.lib.async` module if found else we use the `blink.lib.task` module from blink.lib. README.md is updated to require blink.lib as a dependency for blink.cmp v2 users.

Closes: #12